### PR TITLE
Kostenberechnung für betriebene Stunden 

### DIFF
--- a/Betriebsstundenzaehler/form.json
+++ b/Betriebsstundenzaehler/form.json
@@ -45,6 +45,11 @@
             "suffix": "Minutes"
         },
         {
+            "type": "CheckBox",
+            "name": "CalculateCost",
+            "caption": "CalculateCost"
+        },
+        {
             "type": "NumberSpinner",
             "name": "Price",
             "caption": "Price",

--- a/Betriebsstundenzaehler/form.json
+++ b/Betriebsstundenzaehler/form.json
@@ -1,36 +1,85 @@
 {
     "elements": [
         {
-            "type": "CheckBox", "name": "Active", "caption": "Active"
+            "type": "CheckBox",
+            "name": "Active",
+            "caption": "Active"
         },
         {
-            "type": "SelectVariable", "name": "Source", "caption": "Source"
+            "type": "SelectVariable",
+            "name": "Source",
+            "caption": "Source"
         },
         {
-            "type": "Select", "name": "Level", "caption": "Level", "options": [
-                {"caption": "Day", "value": 1},
-                {"caption": "Week", "value": 2},
-                {"caption": "Month", "value": 3},
-                {"caption": "Year", "value": 4},
-                {"caption": "Complete", "value": 5}
+            "type": "Select",
+            "name": "Level",
+            "caption": "Level",
+            "options": [
+                {
+                    "caption": "Day",
+                    "value": 1
+                },
+                {
+                    "caption": "Week",
+                    "value": 2
+                },
+                {
+                    "caption": "Month",
+                    "value": 3
+                },
+                {
+                    "caption": "Year",
+                    "value": 4
+                },
+                {
+                    "caption": "Complete",
+                    "value": 5
+                }
             ]
         },
         {
-            "type": "NumberSpinner", "name": "Interval", "caption": "Update Interval", "minimum": 1, "suffix": "Minutes"
+            "type": "NumberSpinner",
+            "name": "Interval",
+            "caption": "Update Interval",
+            "minimum": 1,
+            "suffix": "Minutes"
         },
         {
-            "type": "NumberSpinner", "name": "Price", "caption":"Price", "digits":2, "minimum": 0.0, "suffix": "Cent"
+            "type": "NumberSpinner",
+            "name": "Price",
+            "caption": "Price",
+            "digits": 2,
+            "minimum": 0.0,
+            "suffix": "Cent per hour"
         }
     ],
     "actions": [
         {
-            "type": "Button", "caption": "Calculate", "onClick": "BSZ_Calculate($id);"
+            "type": "Button",
+            "caption": "Calculate",
+            "onClick": "BSZ_Calculate($id);"
         }
     ],
     "status": [
-        {"code": 104, "caption": "The instance is inactive.", "icon": "inactive"},
-        {"code": 200, "caption": "Selcted variable does not exist.", "icon": "error"},
-        {"code": 201, "caption": "Selected variable must be logged and of type boolean.", "icon": "error"},
-        {"code": 202, "caption": "No variable selected.", "icon": "error"}
+        {
+            "code": 104,
+            "caption": "The instance is inactive.",
+            "icon": "inactive"
+        },
+        {
+            "code": 200,
+            "caption": "Selcted variable does not exist.",
+            "icon": "error"
+        },
+        {
+            "code": 201,
+            "caption": "Selected variable must be logged and of type boolean.",
+            "icon": "error"
+        },
+        {
+            "code": 202,
+            "caption": "No variable selected.",
+            "icon": "error"
+        }
     ]
 }

--- a/Betriebsstundenzaehler/form.json
+++ b/Betriebsstundenzaehler/form.json
@@ -17,6 +17,9 @@
         },
         {
             "type": "NumberSpinner", "name": "Interval", "caption": "Update Interval", "minimum": 1, "suffix": "Minutes"
+        },
+        {
+            "type": "NumberSpinner", "name": "Price", "caption":"Price", "digits":2, "minimum": 0.0, "suffix": "Cent"
         }
     ],
     "actions": [

--- a/Betriebsstundenzaehler/locale.json
+++ b/Betriebsstundenzaehler/locale.json
@@ -18,10 +18,10 @@
             " hours": " Stunden",
             "Active": "Aktiv",
             "Calculate": "Berechnen",
-            "Cost of this Period": "Kosten des jetzigen Zeitraums",
-            "Cost of the next Period": "Kosten des nächsten Zeitraumes",
-            "Cost of the last Period": "Kosten des letzten Zeitraumes",
-            " cent": "Cent"
+            "Cost of this period": "Kosten des jetzigen Zeitraums",
+            "Prediction end of this period": "Kosten am Ende des Zeitraumes",
+            "Cost of the last period": "Kosten des letzten Zeitraumes",
+            "cent": "Cent"
         }
     }
 }

--- a/Betriebsstundenzaehler/locale.json
+++ b/Betriebsstundenzaehler/locale.json
@@ -17,7 +17,11 @@
             "Hours of Operation": "Betriebsstunden",
             " hours": " Stunden",
             "Active": "Aktiv",
-            "Calculate": "Berechnen"
+            "Calculate": "Berechnen",
+            "Cost of this Period": "Kosten des jetzigen Zeitraums",
+            "Cost of the next Period": "Kosten des nächsten Zeitraumes",
+            "Cost of the last Period": "Kosten des letzten Zeitraumes",
+            " cent": "Cent"
         }
     }
 }

--- a/Betriebsstundenzaehler/module.php
+++ b/Betriebsstundenzaehler/module.php
@@ -131,14 +131,14 @@ class Betriebsstundenzaehler extends IPSModule
 
         //Check aktiv
         if ($this->ReadPropertyBoolean('CalculateCost')) {
-            $this->SetValue('CostLastPeriod', ($getHours($startTimeLastPeriod, ($startTimeThisPeriod - 1)) * $this->ReadPropertyFloat('Price') / 100));
-            $this->SetValue('CostThisPeriod', ($getHours($startTimeThisPeriod, time()) * $this->ReadPropertyFloat('Price') / 100));
+            $this->SetValue('CostThisPeriod', ($getHours($startTimeThisPeriod, $this->getTime()) * $this->ReadPropertyFloat('Price') / 100));
 
             if ($this->ReadPropertyInteger('Level') != LVL_COMPLETE) {
                 $currendDuration = time() - $startTimeThisPeriod;
                 $endOfDuration = $endTimeThisPeriod - $startTimeThisPeriod;
-                $percentOfCurrendPeriod = $currendDuration / $endOfDuration;
+                $percentOfCurrendPeriod = $currendDuration / $endOfDuration * 100;
                 $this->SetValue('PredictionThisPeriod', ($this->GetValue('CostThisPeriod') / $percentOfCurrendPeriod * 100));
+                $this->SetValue('CostLastPeriod', ($getHours($startTimeLastPeriod, ($startTimeThisPeriod - 1)) * $this->ReadPropertyFloat('Price') / 100));
             }
         }
     }

--- a/Betriebsstundenzaehler/module.php
+++ b/Betriebsstundenzaehler/module.php
@@ -164,8 +164,10 @@ class Betriebsstundenzaehler extends IPSModule
         }
 
         $this->MaintainVariable('CostThisPeriod', $this->Translate('Cost of this period'), VARIABLETYPE_FLOAT, '~Euro', 0, $this->ReadPropertyBoolean('CalculateCost'));
-        $this->MaintainVariable('PredictionThisPeriod', $this->Translate('Prediction end of this period'), VARIABLETYPE_FLOAT, '~Euro', 0, $this->ReadPropertyBoolean('CalculateCost'));
-        $this->MaintainVariable('CostLastPeriod', $this->Translate('Cost of the last period'), VARIABLETYPE_FLOAT, '~Euro', 0, $this->ReadPropertyBoolean('CalculateCost'));
+
+        $visible = $this->ReadPropertyBoolean('CalculateCost') && ($this->ReadPropertyInteger('Level') != LVL_COMPLETE);
+        $this->MaintainVariable('PredictionThisPeriod', $this->Translate('Prediction end of this period'), VARIABLETYPE_FLOAT, '~Euro', 0, $visible);
+        $this->MaintainVariable('CostLastPeriod', $this->Translate('Cost of the last period'), VARIABLETYPE_FLOAT, '~Euro', 0, $visible);
 
         $this->Calculate();
     }


### PR DESCRIPTION
Aufgabe war die Kosten für einen ausgewählten Zeitraum zu berechnen.  Dafür legte ich drei zusätzliche Variablen an um die Kosten der laufenden Periode, die Kosten der letzten Periode und um eine Voraussage der nächsten Kosten anzuzeigen.  
Die Kosten der laufenden Periode berechnen sich aus den errechneten Betriebsstunden und dem angegebenen Preis (ct/kWh). 
Die Kosten der letzten Periode berechnen sich wie die laufenden kosten mit anderen Zeitangaben. 
Die Voraussage berechnet sich aus den aktuellen Kosten, welcher mit dem Preis multipliziert wird. 
Um Wiederholungen des Codes bei der Berechnung der Stunden zu vermeiden, setzte ich diese in eine anonyme Funktion, welche den Start- und Endzeitpunkt übergeben bekommt und die Betriebsstunden zurückgibt. 