### PR TITLE
Hinzufügen der Option verschieden Preistypen zu nutzen

### DIFF
--- a/Betriebsstundenzaehler/README.md
+++ b/Betriebsstundenzaehler/README.md
@@ -40,6 +40,7 @@ Quelle                   | Die Variable vom Typ Boolean, welche den Aktivitätss
 Stufe                    | Die Stufe legt den Beginn des Zeitraums fest welcher betrachtet wird (Beginn des Tages, Woche, Monat, Jahr)
 Aktualisierungsintervall | Das Intervall in Minuten in dem die Betriebszeit erneut berechnet wird
 Kostenberechnung         | Legt fest ob die Kostenberechnung ausgeführt werden
+Preistyp                 | Option, ob der Preis fest gelegt ist oder dynamisch über eine Variable berechnet werden soll
 Preis                    | Der Preis welcher pro Betriebsstunde berechnet wird
 Berechnen                | Berechnet die Betriebszeit mit allen angegebenen Parametern
 
@@ -74,3 +75,19 @@ Die Betriebsstunden-Variable wird auf den errechneten Wert gesetzt.
 
 Beispiel:
 `BSZ_Calculate(12345);`
+
+
+`void BSZ_FormPriceType(integer $InstanzID, String $value);`
+
+Setzt die Sichtbarkeit der Preistyp Option im Konfigurationsformular.
+
+Beispiel:
+`BSZ_FormPriceType(12345, "Static");`
+
+
+`void BSZ_FormCalculateCost(integer $InstanzID, String $value);`
+
+Setzt die Sichtbarkeit der Preisoption im Konfigurationsformular.
+
+Beispiel:
+`BSZ_FormCalculateCost(12345, true);`

--- a/Betriebsstundenzaehler/README.md
+++ b/Betriebsstundenzaehler/README.md
@@ -16,6 +16,7 @@ Mithilfe des Betriebsstundenzähler-Moduls kann die Betriebszeit eines Gerätes 
 * Anzeige der Stunden, welche ein Gerät aktiv ist
 * Hinzufügen des Geräts durch eine Variable vom Typ Boolean
 * Anzeigen der Kosten für den aktuellen, den letzten Zeitraum und Vorhersage für das Ende des Zeitraums
+* Möglichkeit die Kosten mit einem dynamischen Preis zu berechnen
 
 ### 2. Voraussetzungen
 
@@ -37,12 +38,14 @@ Name                     | Beschreibung
 ------------------------ | ------------------
 Aktiv                    | Legt fest ob die Rechnung auf Basis des eingestellten Intervalls aktualisiert wird
 Quelle                   | Die Variable vom Typ Boolean, welche den Aktivitätsstatus eines Gerätes anzeigt, wobei true als aktiv angesehen wird. Um die Betriebsstunden zu errechnen muss diese Variable geloggt sein
-Stufe                    | Die Stufe legt den Beginn des Zeitraums fest welcher betrachtet wird (Beginn des Tages, Woche, Monat, Jahr)
+Stufe                    | Die Stufe legt den Beginn des Zeitraums fest welcher betrachtet wird (Beginn des Tages, Woche, Monat, Jahr) sowie die Aggregationsstufe
 Aktualisierungsintervall | Das Intervall in Minuten in dem die Betriebszeit erneut berechnet wird
 Kostenberechnung         | Legt fest ob die Kostenberechnung ausgeführt werden
 Preistyp                 | Option, ob der Preis fest gelegt ist oder dynamisch über eine Variable berechnet werden soll
 Preis                    | Der Preis welcher pro Betriebsstunde berechnet wird
 Berechnen                | Berechnet die Betriebszeit mit allen angegebenen Parametern
+
+Ist im Preistyp die Option "Dynamisch" eingestellt, wird eine geloggte Variable gefordert, welche den Kostenpreis beinhaltet. 
 
 ### 5. Statusvariablen und Profile
 
@@ -76,18 +79,3 @@ Die Betriebsstunden-Variable wird auf den errechneten Wert gesetzt.
 Beispiel:
 `BSZ_Calculate(12345);`
 
-
-`void BSZ_FormPriceType(integer $InstanzID, String $value);`
-
-Setzt die Sichtbarkeit der Preistyp Option im Konfigurationsformular.
-
-Beispiel:
-`BSZ_FormPriceType(12345, "Static");`
-
-
-`void BSZ_FormCalculateCost(integer $InstanzID, String $value);`
-
-Setzt die Sichtbarkeit der Preisoption im Konfigurationsformular.
-
-Beispiel:
-`BSZ_FormCalculateCost(12345, true);`

--- a/Betriebsstundenzaehler/form.json
+++ b/Betriebsstundenzaehler/form.json
@@ -48,7 +48,7 @@
             "type": "CheckBox",
             "name": "CalculateCost",
             "caption": "Calculate Cost",
-            "onChange": "BSZ_FormCalculateCost($id, $CalculateCost);"
+            "onChange": "BSZ_FormCalculateCost($id, $CalculateCost, $PriceType);"
         },
         {
             "type": "Select",

--- a/Betriebsstundenzaehler/form.json
+++ b/Betriebsstundenzaehler/form.json
@@ -48,7 +48,7 @@
             "type": "CheckBox",
             "name": "CalculateCost",
             "caption": "Calculate Cost",
-            "onChange": "BSZ_isCalculate($id, $CalculateCost);"
+            "onChange": "BSZ_FormCalculateCost($id, $CalculateCost);"
         },
         {
             "type": "Select",
@@ -64,7 +64,7 @@
                     "value": "Dynamic"
                 }
             ],
-            "onChange": "BSZ_PriceType($id, $PriceType);"
+            "onChange": "BSZ_FormPriceType($id, $PriceType);"
         },
         {
             "type": "NumberSpinner",

--- a/Betriebsstundenzaehler/form.json
+++ b/Betriebsstundenzaehler/form.json
@@ -47,7 +47,24 @@
         {
             "type": "CheckBox",
             "name": "CalculateCost",
-            "caption": "Calculate Cost"
+            "caption": "Calculate Cost",
+            "onChange": "BSZ_isCalculate($id, $CalculateCost);"
+        },
+        {
+            "type": "Select",
+            "name": "PriceType",
+            "caption": "Price type",
+            "options": [
+                {
+                    "caption": "Static",
+                    "value": "Static"
+                },
+                {
+                    "caption": "Dynamic",
+                    "value": "Dynamic"
+                }
+            ],
+            "onChange": "BSZ_PriceType($id, $PriceType);"
         },
         {
             "type": "NumberSpinner",
@@ -55,7 +72,14 @@
             "caption": "Price",
             "digits": 2,
             "minimum": 0.0,
-            "suffix": "Cent per hour"
+            "suffix": "Cent per hour",
+            "visible": true
+        },
+        {
+            "type": "SelectVariable",
+            "name": "PriceDynamic",
+            "caption": "Price",
+            "visible": false
         }
     ],
     "actions": [

--- a/Betriebsstundenzaehler/locale.json
+++ b/Betriebsstundenzaehler/locale.json
@@ -24,7 +24,7 @@
             "Cent per hour": "Cent pro Stunde",
             "Calculate Cost": "Kostenberechnung",
             "Price": "Preis",
-            "Price type": "Preis Typ",
+            "Price type": "Preistyp",
             "Static": "Statisch",
             "Dynamic": "Dynamisch"
         }

--- a/Betriebsstundenzaehler/locale.json
+++ b/Betriebsstundenzaehler/locale.json
@@ -23,7 +23,10 @@
             "Cost of the last period": "Kosten des letzten Zeitraumes",
             "Cent per hour": "Cent pro Stunde",
             "Calculate Cost": "Kostenberechnung",
-            "Price": "Preis"
+            "Price": "Preis",
+            "Price type": "Preis Typ",
+            "Static": "Statisch",
+            "Dynamic": "Dynamisch"
         }
     }
 }

--- a/Betriebsstundenzaehler/module.php
+++ b/Betriebsstundenzaehler/module.php
@@ -84,7 +84,7 @@ class Betriebsstundenzaehler extends IPSModule
         return json_encode($form);
     }
 
-    public function PriceType(string $status)
+    public function FormPriceType(string $status)
     {
         if ($status == 'Static') {
             $this->UpdateFormField('Price', 'visible', true);
@@ -95,7 +95,7 @@ class Betriebsstundenzaehler extends IPSModule
         }
     }
 
-    public function isCalculate(bool $calculate)
+    public function FormCalculateCost(bool $calculate)
     {
         if ($calculate) {
             $this->UpdateFormField('PriceType', 'visible', true);

--- a/Betriebsstundenzaehler/module.php
+++ b/Betriebsstundenzaehler/module.php
@@ -195,7 +195,7 @@ class Betriebsstundenzaehler extends IPSModule
                 $currentDuration = $this->getTime() - $startTimeThisPeriod;
                 $previousDuration = $endTimeThisPeriod - $startTimeThisPeriod;
                 $percentOfCurrentPeriod = $currentDuration / $previousDuration * 100;
-                
+
                 $this->SetValue('PredictionThisPeriod', $this->GetValue('CostThisPeriod') / $percentOfCurrentPeriod * 100);
 
                 switch ($priceType) {

--- a/tests/BetriebsstundenzaehlerTest.php
+++ b/tests/BetriebsstundenzaehlerTest.php
@@ -406,7 +406,7 @@ class BetriebsstundenzaehlerTest extends TestBase
         $this->assertEquals(3.6, GetValue(IPS_GetObjectIDByIdent('OperatingHours', $instanceID)));
         $this->assertEquals(94.608, GetValue(IPS_GetObjectIDByIdent('CostThisPeriod', $instanceID)));
         $this->assertEquals(88.128, GetValue(IPS_GetObjectIDByIdent('CostLastPeriod', $instanceID)));
-        $this->assertEquals(189.216 , GetValue(IPS_GetObjectIDByIdent('PredictionThisPeriod', $instanceID)));
+        $this->assertEquals(189.216, GetValue(IPS_GetObjectIDByIdent('PredictionThisPeriod', $instanceID)));
 
         /**
          * Manuelle Berechnung:


### PR DESCRIPTION
Mit der Option kann der Nutzer entscheiden ob der Preis fest eingestellt sein oder mit eine geloggt Variable dynamisch berechnet werden soll. 

close https://github.com/symcon/modules/issues/227